### PR TITLE
feat: multiplayer overhaul + site nav/countdown updates

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,9 +21,9 @@ document.querySelectorAll(".nav-links a").forEach((a) => {
   });
 });
 
-// Countdown — Próxima LAN: Sábado 28 Feb 2026, 18:00hs Argentina (UTC-3)
+// Countdown — Próxima LAN: Sábado 30 May 2026, 18:00hs Argentina (UTC-3)
 function initCountdown() {
-  const target = new Date("2026-03-01T21:00:00Z"); // 28 Feb 18:00 ART = UTC-3 → UTC 21:00
+  const target = new Date("2026-05-30T21:00:00Z"); // 30 May 18:00 ART = UTC-3 → UTC 21:00
 
   function tick() {
     const now = new Date();

--- a/game/index.html
+++ b/game/index.html
@@ -18,7 +18,7 @@
       position:fixed; left:16px; top:16px; z-index:5;
       background:rgba(0,0,0,.35); border:1px solid var(--line);
       padding:12px; border-radius:14px; backdrop-filter: blur(8px);
-      min-width: 320px;
+      min-width: 340px;
     }
     .row{display:flex; align-items:center; justify-content:space-between; gap:10px; margin:6px 0;}
     .title{font-weight:900; letter-spacing:.5px}
@@ -27,6 +27,9 @@
     .pill{font-size:12px; padding:4px 8px; border-radius:999px; border:1px solid rgba(255,122,24,.35); color:var(--orange2); background:rgba(255,122,24,.10);}
     .pill.ct{border-color:rgba(100,200,255,.35); color:var(--ct); background:rgba(100,200,255,.08);}
     .pill.t{border-color:rgba(255,155,61,.35); color:var(--t); background:rgba(255,155,61,.10);}
+    .score-t{color:var(--t); font-weight:800; font-family: ui-monospace, Menlo, monospace; font-size:14px;}
+    .score-ct{color:var(--ct); font-weight:800; font-family: ui-monospace, Menlo, monospace; font-size:14px;}
+    .score-sep{color:rgba(233,238,246,.3); margin:0 6px;}
     .right{
       position:fixed; right:16px; top:16px; z-index:5;
       background:rgba(0,0,0,.35); border:1px solid var(--line);
@@ -60,23 +63,50 @@
     }
     input:focus, select:focus{ border-color:rgba(255,122,24,.35); box-shadow:0 0 0 3px rgba(255,122,24,.12); }
     .hint{ font-size:12px; color:rgba(233,238,246,.55); line-height:1.5; margin-top:10px;}
+    /* Kill feed */
+    #killfeed{ margin-top:8px; }
+    .kf-entry{ font-size:11px; font-family: ui-monospace, Menlo, monospace; color:rgba(233,238,246,.7); line-height:1.8; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+    .kf-killer{color:var(--orange2);}
+    .kf-victim{color:rgba(233,238,246,.5);}
   </style>
 </head>
 <body>
+  <!-- Left HUD -->
   <div class="hud">
     <div class="row">
       <div class="title">AIRA-LAN · Mini-CS 2D</div>
       <span class="pill" id="phasePill">FREEZE</span>
     </div>
-    <div class="row"><div class="muted">Jugador</div><div class="kbd" id="me"></div></div>
-    <div class="row"><div class="muted">Equipo</div><div class="kbd" id="team"></div></div>
-    <div class="row"><div class="muted">HP</div><div class="kbd" id="hp"></div></div>
-    <div class="row"><div class="muted">Ammo</div><div class="kbd" id="ammo"></div></div>
-    <div class="row"><div class="muted">Objetivo</div><div class="kbd" id="obj"></div></div>
-    <div class="row"><div class="muted">Controles</div><div class="kbd">WASD · Mouse aim · Click shoot · R recargar · E interact</div></div>
-    <div class="row"><button class="btn" id="restart">Restart</button><div class="muted" id="net">offline</div></div>
+    <div class="row">
+      <div class="muted">Jugador</div><div class="kbd" id="me"></div>
+    </div>
+    <div class="row">
+      <div class="muted">Equipo</div><div class="kbd" id="team"></div>
+    </div>
+    <div class="row">
+      <div class="muted">HP</div><div class="kbd" id="hp"></div>
+    </div>
+    <div class="row">
+      <div class="muted">Ammo</div><div class="kbd" id="ammo"></div>
+    </div>
+    <div class="row">
+      <div class="muted">Objetivo</div><div class="kbd" id="obj"></div>
+    </div>
+    <div class="row">
+      <div class="muted">Score</div>
+      <div><span class="score-t" id="scoreT">T: 0</span><span class="score-sep">·</span><span class="score-ct" id="scoreCT">CT: 0</span></div>
+    </div>
+    <div class="row">
+      <div class="muted">Controles</div>
+      <div class="kbd">WASD · Mouse aim · Click disparo · R recargar · E interact</div>
+    </div>
+    <div class="row">
+      <button class="btn" id="restart">Restart</button>
+      <div class="muted" id="net">offline</div>
+    </div>
   </div>
 
+  <!-- Right HUD -->
   <div class="right">
     <div class="row"><div class="title">Ronda</div><div class="kbd" id="round"></div></div>
     <div class="row"><div class="muted">Timer</div><div class="kbd" id="timer"></div></div>
@@ -85,11 +115,16 @@
       <button class="btn" id="swap">Cambiar Team</button>
       <button class="btn ct" id="resetScore">Reset Score</button>
     </div>
+    <div style="margin-top:8px; border-top:1px solid var(--line); padding-top:8px;">
+      <div class="muted" style="font-size:11px; margin-bottom:4px;">KILL FEED</div>
+      <div id="killfeed"></div>
+    </div>
     <div class="hint">
-      Multiplayer: agregá un server WS (opcional). En GitHub Pages, el juego va offline.
+      Multiplayer: iniciá el server WS (node server.js) y conectate por LAN.
     </div>
   </div>
 
+  <!-- Join overlay -->
   <div class="overlay" id="overlay">
     <div class="card">
       <div class="title" style="margin-bottom:10px;">Entrar a la partida</div>
@@ -109,12 +144,12 @@
       </div>
       <div class="row" style="margin-top:12px;">
         <button class="btn" id="play">Jugar</button>
-        <span class="kbd" style="opacity:.7;">Tip: si no ponés WS, es offline</span>
+        <span class="kbd" style="opacity:.7;">Sin WS = modo offline</span>
       </div>
       <div class="hint">
         Objetivo CS-lite:<br>
-        - <b>T</b>: plantá bomba en A o B (E).<br>
-        - <b>CT</b>: evitá el plant o defuse (E) si está plantada.
+        - <b>T</b>: plantá bomba en A o B (mantené E).<br>
+        - <b>CT</b>: evitá el plant o defusea (E) si está plantada.
       </div>
     </div>
   </div>
@@ -125,616 +160,749 @@
 (() => {
   const NAMES = ["Chispita","Emma.bf","Moby","GRO0T","KungFu","toyito","Damo","Rope","ShEePoG","McLane","Ulicezbot","Simo"];
 
-  // Canvas
+  // ── Canvas ──────────────────────────────────────────────────────────────────
   const canvas = document.getElementById("c");
-  const ctx = canvas.getContext("2d", { alpha:false });
-  function resize(){
-    const dpr = Math.max(1, Math.min(2, devicePixelRatio||1));
-    canvas.width = Math.floor(innerWidth*dpr);
-    canvas.height = Math.floor(innerHeight*dpr);
-    canvas.style.width = innerWidth+"px";
-    canvas.style.height = innerHeight+"px";
-    ctx.setTransform(dpr,0,0,dpr,0,0);
+  const ctx = canvas.getContext("2d", { alpha: false });
+  function resize() {
+    const dpr = Math.max(1, Math.min(2, devicePixelRatio || 1));
+    canvas.width  = Math.floor(innerWidth  * dpr);
+    canvas.height = Math.floor(innerHeight * dpr);
+    canvas.style.width  = innerWidth  + "px";
+    canvas.style.height = innerHeight + "px";
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   }
   addEventListener("resize", resize); resize();
 
-  // UI
+  // ── UI refs ─────────────────────────────────────────────────────────────────
   const ui = {
-    overlay: document.getElementById("overlay"),
-    nameSel: document.getElementById("nameSel"),
-    teamSel: document.getElementById("teamSel"),
-    wsUrl: document.getElementById("wsUrl"),
-    play: document.getElementById("play"),
-
-    me: document.getElementById("me"),
-    team: document.getElementById("team"),
-    hp: document.getElementById("hp"),
-    ammo: document.getElementById("ammo"),
-    obj: document.getElementById("obj"),
-    net: document.getElementById("net"),
-
-    round: document.getElementById("round"),
-    timer: document.getElementById("timer"),
-    bomb: document.getElementById("bomb"),
+    overlay:   document.getElementById("overlay"),
+    nameSel:   document.getElementById("nameSel"),
+    teamSel:   document.getElementById("teamSel"),
+    wsUrl:     document.getElementById("wsUrl"),
+    play:      document.getElementById("play"),
+    me:        document.getElementById("me"),
+    team:      document.getElementById("team"),
+    hp:        document.getElementById("hp"),
+    ammo:      document.getElementById("ammo"),
+    obj:       document.getElementById("obj"),
+    net:       document.getElementById("net"),
+    round:     document.getElementById("round"),
+    timer:     document.getElementById("timer"),
+    bomb:      document.getElementById("bomb"),
     phasePill: document.getElementById("phasePill"),
-
-    restart: document.getElementById("restart"),
-    swap: document.getElementById("swap"),
-    resetScore: document.getElementById("resetScore"),
+    scoreT:    document.getElementById("scoreT"),
+    scoreCT:   document.getElementById("scoreCT"),
+    killfeed:  document.getElementById("killfeed"),
+    restart:   document.getElementById("restart"),
+    swap:      document.getElementById("swap"),
+    resetScore:document.getElementById("resetScore"),
   };
-
-  ui.nameSel.innerHTML = NAMES.map(n=>`<option value="${n}">${n}</option>`).join("");
+  ui.nameSel.innerHTML = NAMES.map(n => `<option value="${n}">${n}</option>`).join("");
   ui.nameSel.value = "Damo";
 
-  // Input
-  const keys = new Set();
-  addEventListener("keydown", e => keys.add(e.key.toLowerCase()));
-  addEventListener("keyup", e => keys.delete(e.key.toLowerCase()));
-  const mouse = { x: innerWidth/2, y: innerHeight/2, down:false };
-  addEventListener("mousemove", e => { mouse.x=e.clientX; mouse.y=e.clientY; });
-  addEventListener("mousedown", () => mouse.down=true);
-  addEventListener("mouseup", () => mouse.down=false);
+  // ── Input ───────────────────────────────────────────────────────────────────
+  const keys  = new Set();
+  const mouse = { x: innerWidth / 2, y: innerHeight / 2, down: false };
+  addEventListener("keydown",   e => keys.add(e.key.toLowerCase()));
+  addEventListener("keyup",     e => keys.delete(e.key.toLowerCase()));
+  addEventListener("mousemove", e => { mouse.x = e.clientX; mouse.y = e.clientY; });
+  addEventListener("mousedown", () => mouse.down = true);
+  addEventListener("mouseup",   () => mouse.down = false);
 
-  // World / Map (más “CS”)
+  // ── World / Map ─────────────────────────────────────────────────────────────
   const world = {
-    w: 2400,
-    h: 1500,
+    w: 2400, h: 1500,
     walls: [
-      // Bordes internos + “pasillos”
-      {x:260,y:240,w:680,h:70},
-      {x:1040,y:170,w:70,h:520},
-      {x:1460,y:310,w:520,h:70},
-      {x:700,y:760,w:70,h:520},
-      {x:1160,y:900,w:600,h:70},
-      {x:1860,y:640,w:70,h:520},
-      {x:280,y:1030,w:520,h:70},
-
-      // Extras para “mid”
-      {x:900,y:520,w:400,h:60},
-      {x:1260,y:560,w:60,h:300},
-      {x:480,y:520,w:60,h:320},
-      {x:520,y:820,w:320,h:60},
+      {x:260, y:240,  w:680, h:70},
+      {x:1040,y:170,  w:70,  h:520},
+      {x:1460,y:310,  w:520, h:70},
+      {x:700, y:760,  w:70,  h:520},
+      {x:1160,y:900,  w:600, h:70},
+      {x:1860,y:640,  w:70,  h:520},
+      {x:280, y:1030, w:520, h:70},
+      {x:900, y:520,  w:400, h:60},
+      {x:1260,y:560,  w:60,  h:300},
+      {x:480, y:520,  w:60,  h:320},
+      {x:520, y:820,  w:320, h:60},
     ],
     spawns: {
-      T:  [{x:220,y:1300},{x:320,y:1260},{x:260,y:1180}],
-      CT: [{x:2140,y:240},{x:2040,y:320},{x:2200,y:340}],
+      T:  [{x:220, y:1300}, {x:320, y:1260}, {x:260, y:1180}],
+      CT: [{x:2140,y:240},  {x:2040,y:320},  {x:2200,y:340}],
     },
     sites: {
-      A: {x:1900,y:260,w:260,h:220},
-      B: {x:300,y:250,w:260,h:220},
-    }
+      A: {x:1900, y:260,  w:260, h:220},
+      B: {x:300,  y:250,  w:260, h:220},
+    },
   };
 
-  // Helpers
-  const clamp = (v,min,max)=>Math.max(min,Math.min(max,v));
-  const rand = (a,b)=>Math.random()*(b-a)+a;
+  // ── Constants ───────────────────────────────────────────────────────────────
+  const PLAYER_R    = 18;
+  const PLANT_TIME  = 1.6;
+  const DEFUSE_TIME = 3.2;
 
-  function circleRectCollide(cx,cy,r, rect){
-    const nx = clamp(cx, rect.x, rect.x+rect.w);
-    const ny = clamp(cy, rect.y, rect.y+rect.h);
-    const dx = cx-nx, dy = cy-ny;
-    return (dx*dx+dy*dy) <= r*r;
+  // ── Helpers ─────────────────────────────────────────────────────────────────
+  const clamp = (v, mn, mx) => Math.max(mn, Math.min(mx, v));
+  const rand  = (a, b) => Math.random() * (b - a) + a;
+
+  function circleRectCollide(cx, cy, r, rect) {
+    const nx = clamp(cx, rect.x, rect.x + rect.w);
+    const ny = clamp(cy, rect.y, rect.y + rect.h);
+    const dx = cx - nx, dy = cy - ny;
+    return (dx * dx + dy * dy) <= r * r;
+  }
+  function inRect(px, py, r) {
+    return px >= r.x && px <= r.x + r.w && py >= r.y && py <= r.y + r.h;
   }
 
-  // Multiplayer (opcional)
-  let ws = null;
+  // ── Multiplayer ─────────────────────────────────────────────────────────────
+  let ws      = null;
   let netMode = "offline";
-  const remotePlayers = new Map(); // id -> {x,y,team,name,hp}
+  const remotePlayers = new Map(); // id → {id, name, team, x, y, aim, hp, alive}
 
-  function wsConnect(url, me){
-    try{
-      ws = new WebSocket(url);
-    } catch { ws=null; return; }
-
+  function wsConnect(url, me) {
+    try { ws = new WebSocket(url); } catch { ws = null; return; }
     ws.onopen = () => {
       netMode = "online";
       ui.net.textContent = "online";
-      ws.send(JSON.stringify({t:"join", name:me.name, team:me.team}));
+      ws.send(JSON.stringify({ t: "join", name: me.name, team: me.team }));
     };
-    ws.onclose = () => { netMode="offline"; ui.net.textContent="offline"; ws=null; remotePlayers.clear(); };
-    ws.onerror = () => { netMode="offline"; ui.net.textContent="offline"; };
-
-    ws.onmessage = (ev) => {
-      let msg; try{ msg = JSON.parse(ev.data);}catch{ return; }
-      if (msg.t === "you"){ me.id = msg.id; }
-      if (msg.t === "state"){
-        // players array
-        for (const p of msg.players){
-          if (me.id && p.id === me.id) continue;
-          remotePlayers.set(p.id, p);
-        }
-        // cleanup removed
-        for (const id of Array.from(remotePlayers.keys())){
-          if (!msg.players.find(p=>p.id===id)) remotePlayers.delete(id);
-        }
-      }
-      if (msg.t === "shot" && msg.id !== me.id){
-        bullets.push({x:msg.x,y:msg.y,vx:msg.vx,vy:msg.vy,life:1.1, fromRemote:true});
-      }
-      if (msg.t === "bomb"){ bombState = msg.bombState; }
-      if (msg.t === "round"){ roundState = msg.roundState; }
+    ws.onclose = () => {
+      netMode = "offline"; ui.net.textContent = "offline"; ws = null;
+      remotePlayers.clear();
     };
+    ws.onerror = () => { netMode = "offline"; ui.net.textContent = "offline"; };
+    ws.onmessage = ev => handleServerMsg(JSON.parse(ev.data));
   }
 
-  function wsSend(obj){
+  function wsSend(obj) {
     if (!ws || ws.readyState !== 1) return;
     ws.send(JSON.stringify(obj));
   }
 
-  // Player
+  function handleServerMsg(msg) {
+    if (!msg || !msg.t) return;
+
+    // Full authoritative state broadcast
+    if (msg.t === "full") {
+      remotePlayers.clear();
+      for (const p of msg.players) {
+        if (player.id && p.id === player.id) {
+          // Sync our HP/alive from server; server is authority
+          player.hp    = p.hp;
+          player.alive = p.alive;
+        } else {
+          remotePlayers.set(p.id, p);
+        }
+      }
+      // Server-authoritative round & bomb state
+      if (netMode === "online") {
+        roundNum   = msg.round.roundNum;
+        roundState = { ...msg.round };
+        bombState  = { ...msg.bomb };
+        score.T    = msg.score.T;
+        score.CT   = msg.score.CT;
+      }
+      // Kill feed
+      renderKillFeed(msg.kills || []);
+      return;
+    }
+
+    if (msg.t === "you") {
+      player.id = msg.id;
+      return;
+    }
+
+    // Server spawns/respawns us
+    if (msg.t === "respawn") {
+      player.x      = msg.x;
+      player.y      = msg.y;
+      player.hp     = 100;
+      player.alive  = true;
+      player.ammo   = player.magSize;
+      player.reserve = 48;
+      player.reloading = 0;
+      return;
+    }
+
+    // We were killed by someone
+    if (msg.t === "killed") {
+      player.hp    = 0;
+      player.alive = false;
+      return;
+    }
+
+    // We took damage (but not fatal — server already updated hp via "full")
+    if (msg.t === "damage") {
+      // hp updated on next "full" — just a notification hook
+      return;
+    }
+
+    // Remote shot visual
+    if (msg.t === "shot" && msg.id !== player.id) {
+      bullets.push({ x: msg.x, y: msg.y, vx: msg.vx, vy: msg.vy, life: 1.1, fromRemote: true, ownerId: msg.id });
+    }
+  }
+
+  // ── Kill feed rendering ──────────────────────────────────────────────────────
+  function renderKillFeed(kills) {
+    ui.killfeed.innerHTML = kills.map(k =>
+      `<div class="kf-entry"><span class="kf-killer">${escHtml(k.killer)}</span> <span style="color:rgba(255,122,24,.5)">✦</span> <span class="kf-victim">${escHtml(k.victim)}</span></div>`
+    ).join("");
+  }
+  function escHtml(s) {
+    return String(s).replace(/[&<>"']/g, c => ({ "&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;" }[c]));
+  }
+
+  // ── Player ──────────────────────────────────────────────────────────────────
   const player = {
     id: null,
     name: "Damo",
     team: "T",
-    x: world.w/2, y: world.h/2,
-    r: 18, hp: 100,
+    x: world.w / 2, y: world.h / 2,
+    r: PLAYER_R,
+    hp: 100,
+    alive: true,
     speed: 260,
-
     magSize: 12,
     ammo: 12,
     reserve: 48,
     reloadTime: 0.9,
     reloading: 0,
-
     fireRate: 0.13,
     cooldown: 0,
-    recoil: 0
+    recoil: 0,
+    aim: 0, // radians
   };
 
-  // Camera
-  const cam = { x:0, y:0 };
-  function updateCamera(){
-    cam.x = innerWidth/2 - player.x;
-    cam.y = innerHeight/2 - player.y;
-    cam.x = clamp(cam.x, innerWidth - world.w, 0);
-    cam.y = clamp(cam.y, innerHeight - world.h, 0);
-  }
+  // ── Score & round state ─────────────────────────────────────────────────────
+  const score = { T: 0, CT: 0 };
+  let roundNum   = 1;
+  let roundState = { phase: "freeze", phaseLeft: 4.0, liveLeft: 70.0, winner: null, reason: "" };
+  let bombState  = { status: "carried", plantedSite: null, x: null, y: null, timer: 0, plantProgress: 0, defuseProgress: 0 };
+  let plantHold  = 0;
+  let defuseHold = 0;
 
-  // Rounds
-  // freeze -> live -> end (win msg)
-  let roundNum = 1;
-  let roundState = { phase:"freeze", phaseLeft: 4.0, liveLeft: 70.0, winner:null, reason:"" };
-
-  // Bomb
-  // status: "none" | "carried" | "planted" | "exploded" | "defused"
-  let bombState = { status:"carried", carrierTeam:"T", plantedSite:null, x:null,y:null, timer:0, plantHold:0, defuseHold:0 };
-
-  // Bullets
+  // ── Bullets ─────────────────────────────────────────────────────────────────
   const bullets = [];
 
-  function spawnAtTeam(team){
-    const sp = world.spawns[team][Math.floor(Math.random()*world.spawns[team].length)];
+  // ── Camera ──────────────────────────────────────────────────────────────────
+  const cam = { x: 0, y: 0 };
+  function updateCamera() {
+    cam.x = clamp(innerWidth  / 2 - player.x, innerWidth  - world.w, 0);
+    cam.y = clamp(innerHeight / 2 - player.y, innerHeight - world.h, 0);
+  }
+
+  // ── Spawn helpers ────────────────────────────────────────────────────────────
+  function spawnAtTeam(team) {
+    const spawns = world.spawns[team];
+    const sp = spawns[Math.floor(Math.random() * spawns.length)];
     player.x = sp.x; player.y = sp.y;
   }
 
-  function resetRound(toFreeze=true){
-    // reset players
-    player.hp = 100;
-    player.ammo = player.magSize;
-    player.reserve = 48;
+  function resetRoundLocal(toFreeze = true) {
+    player.hp       = 100;
+    player.alive    = true;
+    player.ammo     = player.magSize;
+    player.reserve  = 48;
     player.reloading = 0;
     player.cooldown = 0;
-    player.recoil = 0;
-
+    player.recoil   = 0;
     spawnAtTeam(player.team);
-
-    // reset bomb
-    bombState = { status:"carried", carrierTeam:"T", plantedSite:null, x:null,y:null, timer:0, plantHold:0, defuseHold:0 };
-
-    // reset timers
-    roundState = { phase: toFreeze ? "freeze" : "live", phaseLeft: 4.0, liveLeft: 70.0, winner:null, reason:"" };
-    wsSend({t:"round", roundState});
-    wsSend({t:"bomb", bombState});
+    bombState  = { status: "carried", plantedSite: null, x: null, y: null, timer: 0, plantProgress: 0, defuseProgress: 0 };
+    plantHold  = 0; defuseHold = 0;
+    roundState = { phase: toFreeze ? "freeze" : "live", phaseLeft: 4.0, liveLeft: 70.0, winner: null, reason: "" };
   }
 
-  function endRound(winner, reason){
-    roundState.phase = "end";
-    roundState.winner = winner;
-    roundState.reason = reason;
+  function endRoundLocal(winner, reason) {
+    if (roundState.phase === "end") return;
+    roundState.phase    = "end";
+    roundState.winner   = winner;
+    roundState.reason   = reason;
     roundState.phaseLeft = 3.0;
-    wsSend({t:"round", roundState});
+    score[winner]++;
   }
 
-  function inRect(px,py, r){
-    return (px>=r.x && px<=r.x+r.w && py>=r.y && py<=r.y+r.h);
+  // ── Bomb helpers ─────────────────────────────────────────────────────────────
+  function canPlant() {
+    return player.team === "T" && player.alive && bombState.status === "carried" &&
+           (inRect(player.x, player.y, world.sites.A) || inRect(player.x, player.y, world.sites.B));
   }
-
-  function canPlant(){
-    if (player.team !== "T") return false;
-    if (bombState.status !== "carried") return false;
-    return inRect(player.x, player.y, world.sites.A) || inRect(player.x, player.y, world.sites.B);
-  }
-
-  function currentSite(){
+  function currentSite() {
     if (inRect(player.x, player.y, world.sites.A)) return "A";
     if (inRect(player.x, player.y, world.sites.B)) return "B";
     return null;
   }
-
-  function canDefuse(){
-    if (player.team !== "CT") return false;
-    if (bombState.status !== "planted") return false;
-    const dx = player.x - bombState.x;
-    const dy = player.y - bombState.y;
-    return (dx*dx + dy*dy) <= (80*80);
+  function canDefuse() {
+    if (player.team !== "CT" || !player.alive || bombState.status !== "planted") return false;
+    const dx = player.x - bombState.x, dy = player.y - bombState.y;
+    return dx * dx + dy * dy <= 80 * 80;
   }
 
-  // Shooting
-  function shoot(){
+  // ── Shoot ───────────────────────────────────────────────────────────────────
+  function shoot() {
     if (roundState.phase !== "live") return;
-    if (player.reloading>0) return;
-    if (player.cooldown>0) return;
-    if (player.ammo<=0) return;
+    if (!player.alive) return;
+    if (player.reloading > 0 || player.cooldown > 0 || player.ammo <= 0) return;
 
     player.cooldown = player.fireRate;
     player.ammo -= 1;
     player.recoil = Math.min(10, player.recoil + 1.2);
 
-    const angle = Math.atan2((mouse.y - cam.y) - player.y, (mouse.x - cam.x) - player.x);
-    const spread = (player.recoil * 0.002);
-    const a = angle + rand(-spread, spread);
+    const angle  = Math.atan2((mouse.y - cam.y) - player.y, (mouse.x - cam.x) - player.x);
+    player.aim   = angle;
+    const spread = player.recoil * 0.002;
+    const a      = angle + rand(-spread, spread);
+    const speed  = 820;
 
-    const speed = 820;
     const b = {
-      x: player.x + Math.cos(a)*(player.r+6),
-      y: player.y + Math.sin(a)*(player.r+6),
-      vx: Math.cos(a)*speed,
-      vy: Math.sin(a)*speed,
-      life: 1.1,
-      fromRemote:false
+      x: player.x + Math.cos(a) * (PLAYER_R + 6),
+      y: player.y + Math.sin(a) * (PLAYER_R + 6),
+      vx: Math.cos(a) * speed, vy: Math.sin(a) * speed,
+      life: 1.1, fromRemote: false, ownerId: player.id,
     };
     bullets.push(b);
-
-    // send shot to others
-    wsSend({t:"shot", x:b.x, y:b.y, vx:b.vx, vy:b.vy});
+    wsSend({ t: "shot", x: b.x, y: b.y, vx: b.vx, vy: b.vy });
   }
 
-  function reload(){
-    if (player.reloading>0) return;
-    if (player.ammo === player.magSize) return;
-    if (player.reserve <= 0) return;
+  function reload() {
+    if (player.reloading > 0 || player.ammo === player.magSize || player.reserve <= 0) return;
     player.reloading = player.reloadTime;
   }
 
-  function moveCircle(ent, dx, dy){
+  // ── Movement with wall collision ─────────────────────────────────────────────
+  function moveCircle(ent, dx, dy) {
     ent.x += dx;
     ent.x = clamp(ent.x, ent.r, world.w - ent.r);
-    for (const w of world.walls){
-      if (circleRectCollide(ent.x, ent.y, ent.r, w)){ ent.x -= dx; break; }
+    for (const w of world.walls) {
+      if (circleRectCollide(ent.x, ent.y, ent.r, w)) { ent.x -= dx; break; }
     }
     ent.y += dy;
     ent.y = clamp(ent.y, ent.r, world.h - ent.r);
-    for (const w of world.walls){
-      if (circleRectCollide(ent.x, ent.y, ent.r, w)){ ent.y -= dy; break; }
+    for (const w of world.walls) {
+      if (circleRectCollide(ent.x, ent.y, ent.r, w)) { ent.y -= dy; break; }
     }
   }
 
-  // UI / Lobby
+  // ── UI events ────────────────────────────────────────────────────────────────
   ui.play.onclick = () => {
     player.name = ui.nameSel.value;
     player.team = ui.teamSel.value;
     ui.overlay.style.display = "none";
-
     spawnAtTeam(player.team);
-
     const url = ui.wsUrl.value.trim();
     if (url) wsConnect(url, player);
-
     updateUI();
-    resetRound(true);
+    resetRoundLocal(true);
   };
 
-  ui.restart.onclick = () => resetRound(true);
+  ui.restart.onclick = () => {
+    if (netMode === "online") {
+      // Server controls round — just notify
+      wsSend({ t: "join", name: player.name, team: player.team });
+    } else {
+      resetRoundLocal(true);
+    }
+  };
 
   ui.swap.onclick = () => {
-    player.team = (player.team === "T" ? "CT" : "T");
+    player.team = player.team === "T" ? "CT" : "T";
     spawnAtTeam(player.team);
-    wsSend({t:"join", name:player.name, team:player.team}); // update server state
+    wsSend({ t: "join", name: player.name, team: player.team });
     updateUI();
   };
 
   ui.resetScore.onclick = () => {
-    // solo cosmetic: reinicia ronda / bomba
-    resetRound(true);
+    score.T = 0; score.CT = 0;
+    resetRoundLocal(true);
   };
 
-  function updateUI(){
-    ui.me.textContent = player.name;
-    ui.team.textContent = (player.team === "T" ? "T (Terrorists)" : "CT (Counter-Terrorists)");
-    ui.phasePill.textContent = roundState.phase.toUpperCase();
-    ui.phasePill.className = "pill " + (player.team === "CT" ? "ct" : "t");
-  }
-
-  // Loop
+  // ── Game loop ────────────────────────────────────────────────────────────────
   let last = performance.now();
-  requestAnimationFrame(function loop(now){
-    const dt = Math.min(0.033, (now-last)/1000);
+  requestAnimationFrame(function loop(now) {
+    const dt = Math.min(0.033, (now - last) / 1000);
     last = now;
-
     tick(dt);
     draw();
-
     requestAnimationFrame(loop);
   });
 
-  function tick(dt){
-    // timers
-    if (player.cooldown>0) player.cooldown -= dt;
-    if (player.recoil>0) player.recoil = Math.max(0, player.recoil - dt*6);
+  function tick(dt) {
+    // Cooldowns
+    if (player.cooldown > 0) player.cooldown -= dt;
+    if (player.recoil   > 0) player.recoil = Math.max(0, player.recoil - dt * 6);
 
-    if (player.reloading>0){
+    // Reload
+    if (player.reloading > 0) {
       player.reloading -= dt;
-      if (player.reloading<=0){
+      if (player.reloading <= 0) {
         const need = player.magSize - player.ammo;
         const take = Math.min(need, player.reserve);
-        player.ammo += take;
+        player.ammo    += take;
         player.reserve -= take;
         player.reloading = 0;
       }
     }
 
-    // round phases
-    if (roundState.phase === "freeze"){
-      roundState.phaseLeft -= dt;
-      if (roundState.phaseLeft <= 0){
-        roundState.phase = "live";
-        wsSend({t:"round", roundState});
-      }
-    } else if (roundState.phase === "live"){
-      roundState.liveLeft -= dt;
-
-      // time out => CT win (default)
-      if (roundState.liveLeft <= 0 && bombState.status !== "planted"){
-        endRound("CT", "Tiempo");
-      }
-    } else if (roundState.phase === "end"){
-      roundState.phaseLeft -= dt;
-      if (roundState.phaseLeft <= 0){
-        roundNum++;
-        resetRound(true);
+    // ── Round state (local only when offline) ───────────────────────────────
+    if (netMode !== "online") {
+      if (roundState.phase === "freeze") {
+        roundState.phaseLeft -= dt;
+        if (roundState.phaseLeft <= 0) { roundState.phase = "live"; roundState.phaseLeft = 0; }
+      } else if (roundState.phase === "live") {
+        if (bombState.status === "planted") {
+          bombState.timer -= dt;
+          if (bombState.timer <= 0) { bombState.status = "exploded"; endRoundLocal("T", "Bomba explotó"); }
+        } else {
+          roundState.liveLeft -= dt;
+          if (roundState.liveLeft <= 0) endRoundLocal("CT", "Tiempo");
+        }
+      } else if (roundState.phase === "end") {
+        roundState.phaseLeft -= dt;
+        if (roundState.phaseLeft <= 0) { roundNum++; resetRoundLocal(true); }
       }
     }
 
-    // bomb tick
-    if (bombState.status === "planted"){
-      bombState.timer -= dt;
-      if (bombState.timer <= 0){
-        bombState.status = "exploded";
-        wsSend({t:"bomb", bombState});
-        endRound("T", "Bomba explotó");
-      }
+    // ── Input ────────────────────────────────────────────────────────────────
+    if (keys.has("r") && player.alive) reload();
+
+    // Movement (freeze = no move; dead = no move)
+    if (roundState.phase === "live" && player.alive) {
+      const ax = (keys.has("d") ? 1 : 0) - (keys.has("a") ? 1 : 0);
+      const ay = (keys.has("s") ? 1 : 0) - (keys.has("w") ? 1 : 0);
+      const len = Math.hypot(ax, ay) || 1;
+      moveCircle(player, (ax / len) * player.speed * dt, (ay / len) * player.speed * dt);
     }
 
-    // input
-    if (keys.has("r")) reload();
-
-    const ax = (keys.has("d")?1:0) - (keys.has("a")?1:0);
-    const ay = (keys.has("s")?1:0) - (keys.has("w")?1:0);
-    const len = Math.hypot(ax,ay) || 1;
-    const vx = (ax/len) * player.speed;
-    const vy = (ay/len) * player.speed;
-
-    if (roundState.phase !== "end"){
-      // freeze: no movement
-      if (roundState.phase === "live"){
-        moveCircle(player, vx*dt, vy*dt);
-      }
-    }
-
-    // shoot
+    // Shoot
     if (mouse.down) shoot();
 
-    // interact (E)
-    if (keys.has("e")){
-      if (roundState.phase === "live"){
-        // plant
-        if (canPlant()){
-          bombState.plantHold += dt;
-          if (bombState.plantHold >= 1.6){
-            const site = currentSite();
-            bombState.status = "planted";
-            bombState.plantedSite = site;
-            bombState.x = player.x;
-            bombState.y = player.y;
-            bombState.timer = 35.0;
-            bombState.plantHold = 0;
-            wsSend({t:"bomb", bombState});
-          }
-        } else {
-          bombState.plantHold = 0;
-        }
+    // Aim angle (update continuously for drawing even when not shooting)
+    player.aim = Math.atan2((mouse.y - cam.y) - player.y, (mouse.x - cam.x) - player.x);
 
-        // defuse
-        if (canDefuse()){
-          bombState.defuseHold += dt;
-          if (bombState.defuseHold >= 3.2){
-            bombState.status = "defused";
-            wsSend({t:"bomb", bombState});
-            endRound("CT", "Defuse");
-          }
+    // ── Interact (E) — plant / defuse ────────────────────────────────────────
+    if (keys.has("e") && roundState.phase === "live" && player.alive) {
+      // Plant
+      if (canPlant()) {
+        plantHold += dt;
+        if (netMode === "online") {
+          wsSend({ t: "plant", progress: plantHold / PLANT_TIME });
         } else {
-          bombState.defuseHold = 0;
+          if (plantHold >= PLANT_TIME) {
+            const site = currentSite();
+            bombState.status      = "planted";
+            bombState.plantedSite = site;
+            bombState.x           = player.x;
+            bombState.y           = player.y;
+            bombState.timer       = 35.0;
+            plantHold = 0;
+          }
         }
+      } else {
+        plantHold = 0;
+        if (netMode === "online") wsSend({ t: "actionStop" });
+      }
+
+      // Defuse
+      if (canDefuse()) {
+        defuseHold += dt;
+        if (netMode === "online") {
+          wsSend({ t: "defuse", progress: defuseHold / DEFUSE_TIME });
+        } else {
+          if (defuseHold >= DEFUSE_TIME) {
+            bombState.status = "defused";
+            defuseHold = 0;
+            endRoundLocal("CT", "Defuse");
+          }
+        }
+      } else {
+        defuseHold = 0;
       }
     } else {
-      bombState.plantHold = 0;
-      bombState.defuseHold = 0;
+      if (plantHold > 0 || defuseHold > 0) wsSend({ t: "actionStop" });
+      plantHold  = 0;
+      defuseHold = 0;
     }
 
-    // bullets
-    for (let i=bullets.length-1; i>=0; i--){
+    // ── Bullets ──────────────────────────────────────────────────────────────
+    for (let i = bullets.length - 1; i >= 0; i--) {
       const b = bullets[i];
-      b.x += b.vx*dt;
-      b.y += b.vy*dt;
+      b.x += b.vx * dt;
+      b.y += b.vy * dt;
       b.life -= dt;
 
-      // walls hit
+      // Wall hit
       let hitWall = false;
-      for (const w of world.walls){
-        if (b.x>=w.x && b.x<=w.x+w.w && b.y>=w.y && b.y<=w.y+w.h){ hitWall=true; break; }
-      }
-
-      // hit local player only if remote bullet (para demo)
-      if (!hitWall && b.fromRemote && roundState.phase==="live"){
-        const dx = player.x - b.x, dy = player.y - b.y;
-        if (dx*dx + dy*dy <= player.r*player.r){
-          player.hp -= 20;
-          if (player.hp <= 0){
-            player.hp = 0;
-            endRound(player.team === "T" ? "CT" : "T", "Eliminación");
-          }
-          bullets.splice(i,1);
-          continue;
+      for (const w of world.walls) {
+        if (b.x >= w.x && b.x <= w.x + w.w && b.y >= w.y && b.y <= w.y + w.h) {
+          hitWall = true; break;
         }
       }
 
-      if (b.life<=0 || hitWall) bullets.splice(i,1);
-    }
+      if (!hitWall) {
+        // Local bullet hits remote players (online: report to server)
+        if (!b.fromRemote && roundState.phase === "live" && player.alive) {
+          let hitRemote = false;
+          for (const [, rp] of remotePlayers) {
+            if (!rp.alive || rp.team === player.team) continue;
+            const dx = rp.x - b.x, dy = rp.y - b.y;
+            if (dx * dx + dy * dy <= PLAYER_R * PLAYER_R) {
+              wsSend({ t: "hit", targetId: rp.id, damage: 20 });
+              hitRemote = true;
+              break;
+            }
+          }
+          if (hitRemote) { bullets.splice(i, 1); continue; }
+        }
 
-    // camera + hud text
-    updateCamera();
-    ui.hp.textContent = `${player.hp}/100`;
-    ui.ammo.textContent = `${player.ammo}/${player.reserve}` + (player.reloading>0 ? " (reloading…)" : "");
-
-    ui.round.textContent = `#${roundNum}`;
-    ui.timer.textContent = (roundState.phase==="live" ? `${roundState.liveLeft.toFixed(0)}s` : `${Math.max(0,roundState.phaseLeft).toFixed(0)}s`);
-
-    if (bombState.status === "carried"){
-      ui.bomb.textContent = "No plantada";
-    } else if (bombState.status === "planted"){
-      ui.bomb.textContent = `PLANTED ${bombState.plantedSite} · ${bombState.timer.toFixed(0)}s`;
-    } else if (bombState.status === "defused"){
-      ui.bomb.textContent = "DEFUSED";
-    } else if (bombState.status === "exploded"){
-      ui.bomb.textContent = "BOOM";
-    }
-
-    // objective helper
-    if (roundState.phase === "freeze"){
-      ui.obj.textContent = "Freeze time";
-    } else if (roundState.phase === "end"){
-      ui.obj.textContent = `${roundState.winner} gana · ${roundState.reason}`;
-    } else {
-      if (player.team==="T"){
-        ui.obj.textContent = canPlant() ? `Plantá en ${currentSite()} (E)` : "Buscá A o B para plantar";
-      } else {
-        ui.obj.textContent = canDefuse() ? "Defuse (E)" : (bombState.status==="planted" ? "Andá a la bomba" : "Evitar plant");
+        // Remote bullet hits local player (offline simulation only — online: server handles)
+        if (b.fromRemote && netMode === "offline" && roundState.phase === "live" && player.alive) {
+          const dx = player.x - b.x, dy = player.y - b.y;
+          if (dx * dx + dy * dy <= PLAYER_R * PLAYER_R) {
+            player.hp -= 20;
+            if (player.hp <= 0) {
+              player.hp    = 0;
+              player.alive = false;
+              endRoundLocal(player.team === "T" ? "CT" : "T", "Eliminación");
+            }
+            bullets.splice(i, 1);
+            continue;
+          }
+        }
       }
+
+      if (b.life <= 0 || hitWall) bullets.splice(i, 1);
     }
 
-    // multiplayer state tick
-    if (netMode==="online"){
-      wsSend({t:"pos", x:player.x, y:player.y, hp:player.hp, team:player.team, name:player.name});
-      ui.net.textContent = "online";
-    } else {
-      ui.net.textContent = "offline";
+    // ── Camera & HUD text ────────────────────────────────────────────────────
+    updateCamera();
+
+    // Send position to server
+    if (netMode === "online") {
+      wsSend({ t: "pos", x: player.x, y: player.y, aim: player.aim, hp: player.hp, team: player.team, name: player.name });
     }
 
     updateUI();
   }
 
-  function draw(){
-    // background
-    ctx.fillStyle = "#07090c";
-    ctx.fillRect(0,0,innerWidth,innerHeight);
+  function updateUI() {
+    ui.me.textContent     = player.name;
+    ui.team.textContent   = player.team === "T" ? "T (Terrorists)" : "CT (Counter-Terrorists)";
+    ui.hp.textContent     = player.alive ? `${player.hp}/100` : "MUERTO";
+    ui.ammo.textContent   = `${player.ammo}/${player.reserve}` + (player.reloading > 0 ? " (recargando…)" : "");
+    ui.round.textContent  = `#${roundNum}`;
+    ui.scoreT.textContent = `T: ${score.T}`;
+    ui.scoreCT.textContent= `CT: ${score.CT}`;
+    ui.net.textContent    = netMode;
 
-    // world
+    ui.timer.textContent = roundState.phase === "live"
+      ? `${Math.max(0, roundState.liveLeft).toFixed(0)}s`
+      : `${Math.max(0, roundState.phaseLeft).toFixed(0)}s`;
+
+    // Bomb status
+    if (bombState.status === "carried") {
+      ui.bomb.textContent = "No plantada";
+    } else if (bombState.status === "planted") {
+      ui.bomb.textContent = `PLANTED ${bombState.plantedSite} · ${Math.max(0, bombState.timer).toFixed(0)}s`;
+    } else if (bombState.status === "defused") {
+      ui.bomb.textContent = "DEFUSED";
+    } else if (bombState.status === "exploded") {
+      ui.bomb.textContent = "BOOM";
+    }
+
+    // Phase pill
+    ui.phasePill.textContent = roundState.phase.toUpperCase();
+    ui.phasePill.className = "pill " + (player.team === "CT" ? "ct" : "t");
+
+    // Objective
+    if (roundState.phase === "freeze") {
+      ui.obj.textContent = "Freeze time";
+    } else if (roundState.phase === "end") {
+      ui.obj.textContent = `${roundState.winner} gana · ${roundState.reason}`;
+    } else if (!player.alive) {
+      ui.obj.textContent = "Esperando siguiente ronda…";
+    } else if (player.team === "T") {
+      ui.obj.textContent = canPlant()
+        ? `Plantá en ${currentSite()} (mantené E)`
+        : "Buscá A o B para plantar";
+    } else {
+      ui.obj.textContent = canDefuse()
+        ? "Defusea (mantené E)"
+        : (bombState.status === "planted" ? "Andá a la bomba!" : "Evitar el plant");
+    }
+  }
+
+  // ── Draw ─────────────────────────────────────────────────────────────────────
+  function draw() {
+    ctx.fillStyle = "#07090c";
+    ctx.fillRect(0, 0, innerWidth, innerHeight);
+
     ctx.save();
     ctx.translate(cam.x, cam.y);
 
-    // grid
-    ctx.globalAlpha = 0.10;
+    // Grid
+    ctx.globalAlpha = 0.08;
     ctx.strokeStyle = "white";
-    for (let x=0; x<=world.w; x+=80){ ctx.beginPath(); ctx.moveTo(x,0); ctx.lineTo(x,world.h); ctx.stroke(); }
-    for (let y=0; y<=world.h; y+=80){ ctx.beginPath(); ctx.moveTo(0,y); ctx.lineTo(world.w,y); ctx.stroke(); }
+    for (let x = 0; x <= world.w; x += 80) { ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, world.h); ctx.stroke(); }
+    for (let y = 0; y <= world.h; y += 80) { ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(world.w, y); ctx.stroke(); }
     ctx.globalAlpha = 1;
 
-    // sites A/B
+    // Bomb sites
     drawSite("A", world.sites.A, "rgba(100,200,255,.10)", "rgba(100,200,255,.30)");
-    drawSite("B", world.sites.B, "rgba(255,155,61,.10)", "rgba(255,155,61,.30)");
+    drawSite("B", world.sites.B, "rgba(255,155,61,.10)",  "rgba(255,155,61,.30)");
 
-    // walls
-    for (const w of world.walls){
-      ctx.fillStyle = "rgba(255,255,255,.06)";
-      ctx.fillRect(w.x,w.y,w.w,w.h);
+    // Walls
+    for (const w of world.walls) {
+      ctx.fillStyle  = "rgba(255,255,255,.06)";
+      ctx.fillRect(w.x, w.y, w.w, w.h);
       ctx.strokeStyle = "rgba(255,122,24,.20)";
-      ctx.strokeRect(w.x+0.5,w.y+0.5,w.w-1,w.h-1);
+      ctx.strokeRect(w.x + 0.5, w.y + 0.5, w.w - 1, w.h - 1);
     }
 
-    // bomb on ground
-    if (bombState.status==="planted"){
-      ctx.fillStyle = "rgba(255,122,24,.95)";
-      ctx.beginPath(); ctx.arc(bombState.x, bombState.y, 8, 0, Math.PI*2); ctx.fill();
-      ctx.strokeStyle = "rgba(255,255,255,.2)";
-      ctx.beginPath(); ctx.arc(bombState.x, bombState.y, 30, 0, Math.PI*2); ctx.stroke();
+    // Bomb on ground
+    if (bombState.status === "planted") {
+      const pulse = 0.5 + 0.5 * Math.sin(Date.now() / 200);
+      ctx.fillStyle = `rgba(255,${Math.floor(80 + pulse * 42)},24,.95)`;
+      ctx.beginPath(); ctx.arc(bombState.x, bombState.y, 8, 0, Math.PI * 2); ctx.fill();
+      ctx.strokeStyle = `rgba(255,122,24,${0.3 + pulse * 0.3})`;
+      ctx.lineWidth = 2;
+      ctx.beginPath(); ctx.arc(bombState.x, bombState.y, 24 + pulse * 8, 0, Math.PI * 2); ctx.stroke();
+      ctx.lineWidth = 1;
     }
 
-    // remote players
-    for (const p of remotePlayers.values()){
-      drawAgent(p, p.team==="CT" ? "rgba(100,200,255,.95)" : "rgba(255,155,61,.95)");
-      drawName(p.name, p.x, p.y - 34, "rgba(233,238,246,.8)");
+    // Remote players
+    for (const p of remotePlayers.values()) {
+      const fill = p.team === "CT" ? "rgba(100,200,255,.95)" : "rgba(255,155,61,.95)";
+      drawAgent(p, fill, p.aim, p.alive);
+      if (p.alive) drawName(p.name, p.x, p.y - 34, "rgba(233,238,246,.8)");
     }
 
-    // local player
-    drawAgent(player, player.team==="CT" ? "rgba(100,200,255,.95)" : "rgba(255,155,61,.95)");
+    // Local player
+    const localFill = player.team === "CT" ? "rgba(100,200,255,.95)" : "rgba(255,155,61,.95)";
+    drawAgent(player, localFill, player.aim, player.alive);
     drawName(player.name, player.x, player.y - 34, "rgba(233,238,246,.92)");
 
-    // aim line
-    const tx = (mouse.x - cam.x), ty = (mouse.y - cam.y);
-    ctx.strokeStyle = "rgba(255,122,24,.25)";
-    ctx.beginPath(); ctx.moveTo(player.x, player.y); ctx.lineTo(tx,ty); ctx.stroke();
+    // Aim line (only when alive)
+    if (player.alive && roundState.phase === "live") {
+      const tx = mouse.x - cam.x, ty = mouse.y - cam.y;
+      ctx.strokeStyle = "rgba(255,122,24,.18)";
+      ctx.setLineDash([4, 8]);
+      ctx.beginPath(); ctx.moveTo(player.x, player.y); ctx.lineTo(tx, ty); ctx.stroke();
+      ctx.setLineDash([]);
+    }
 
-    // bullets
-    ctx.fillStyle = "rgba(255,155,61,.95)";
-    for (const b of bullets){
-      ctx.beginPath(); ctx.arc(b.x,b.y,3,0,Math.PI*2); ctx.fill();
+    // Bullets
+    for (const b of bullets) {
+      ctx.fillStyle = b.fromRemote ? "rgba(255,80,80,.9)" : "rgba(255,155,61,.95)";
+      ctx.beginPath(); ctx.arc(b.x, b.y, 3, 0, Math.PI * 2); ctx.fill();
+    }
+
+    // Plant/defuse progress bar
+    const actionProgress = plantHold > 0
+      ? { p: plantHold / PLANT_TIME,  label: "PLANTANDO…" }
+      : defuseHold > 0
+      ? { p: defuseHold / DEFUSE_TIME, label: "DEFUSEANDO…" }
+      : null;
+
+    if (actionProgress) {
+      const barW = 220, barH = 8;
+      const bx   = innerWidth / 2 - barW / 2;
+      const by   = innerHeight - 70;
+      ctx.fillStyle = "rgba(0,0,0,.6)";
+      ctx.fillRect(bx - 8, by - 24, barW + 16, barH + 34);
+      ctx.fillStyle = "rgba(255,122,24,.2)";
+      ctx.fillRect(bx, by, barW, barH);
+      ctx.fillStyle = "rgba(255,122,24,.95)";
+      ctx.fillRect(bx, by, barW * Math.min(1, actionProgress.p), barH);
+      ctx.fillStyle = "rgba(233,238,246,.9)";
+      ctx.font = "bold 12px ui-monospace, Menlo, monospace";
+      ctx.textAlign = "center";
+      ctx.fillText(actionProgress.label, innerWidth / 2, by - 6);
+      ctx.textAlign = "left";
     }
 
     ctx.restore();
 
-    // crosshair
-    ctx.strokeStyle = "rgba(255,155,61,.85)";
-    ctx.beginPath();
-    ctx.moveTo(mouse.x-10, mouse.y); ctx.lineTo(mouse.x-4, mouse.y);
-    ctx.moveTo(mouse.x+4, mouse.y); ctx.lineTo(mouse.x+10, mouse.y);
-    ctx.moveTo(mouse.x, mouse.y-10); ctx.lineTo(mouse.x, mouse.y-4);
-    ctx.moveTo(mouse.x, mouse.y+4); ctx.lineTo(mouse.x, mouse.y+10);
-    ctx.stroke();
+    // Crosshair
+    if (player.alive) {
+      const gap = 4 + player.recoil * 0.5;
+      ctx.strokeStyle = "rgba(255,155,61,.85)";
+      ctx.lineWidth   = 1.5;
+      ctx.beginPath();
+      ctx.moveTo(mouse.x - 10, mouse.y); ctx.lineTo(mouse.x - gap, mouse.y);
+      ctx.moveTo(mouse.x + gap, mouse.y); ctx.lineTo(mouse.x + 10, mouse.y);
+      ctx.moveTo(mouse.x, mouse.y - 10); ctx.lineTo(mouse.x, mouse.y - gap);
+      ctx.moveTo(mouse.x, mouse.y + gap); ctx.lineTo(mouse.x, mouse.y + 10);
+      ctx.stroke();
+      ctx.lineWidth = 1;
+    }
+
+    // Dead overlay
+    if (!player.alive) {
+      ctx.fillStyle = "rgba(160,10,10,.22)";
+      ctx.fillRect(0, 0, innerWidth, innerHeight);
+      ctx.fillStyle = "rgba(233,238,246,.9)";
+      ctx.font = "bold 32px ui-monospace, Menlo, monospace";
+      ctx.textAlign = "center";
+      ctx.fillText("MUERTO", innerWidth / 2, innerHeight / 2 - 18);
+      ctx.font = "13px ui-monospace, Menlo, monospace";
+      ctx.fillStyle = "rgba(233,238,246,.5)";
+      ctx.fillText("Esperando siguiente ronda…", innerWidth / 2, innerHeight / 2 + 14);
+      ctx.textAlign = "left";
+    }
+
+    // Round-end overlay
+    if (roundState.phase === "end") {
+      const winner = roundState.winner;
+      const isOurs = winner === player.team;
+      ctx.fillStyle = isOurs ? "rgba(0,80,0,.25)" : "rgba(80,0,0,.25)";
+      ctx.fillRect(0, 0, innerWidth, innerHeight);
+      ctx.fillStyle = isOurs ? "rgba(100,255,120,.95)" : "rgba(255,80,80,.95)";
+      ctx.font = "bold 36px ui-monospace, Menlo, monospace";
+      ctx.textAlign = "center";
+      ctx.fillText(`${winner} gana · ${roundState.reason}`, innerWidth / 2, innerHeight / 2 - 10);
+      ctx.font = "14px ui-monospace, Menlo, monospace";
+      ctx.fillStyle = "rgba(233,238,246,.6)";
+      ctx.fillText(`Ronda ${roundNum} · T:${score.T}  CT:${score.CT}`, innerWidth / 2, innerHeight / 2 + 22);
+      ctx.textAlign = "left";
+    }
   }
 
-  function drawSite(label, r, fill, stroke){
+  function drawSite(label, r, fill, stroke) {
     ctx.fillStyle = fill;
     ctx.fillRect(r.x, r.y, r.w, r.h);
     ctx.strokeStyle = stroke;
-    ctx.strokeRect(r.x+0.5, r.y+0.5, r.w-1, r.h-1);
-    ctx.fillStyle = "rgba(0,0,0,.45)";
-    ctx.fillRect(r.x+8, r.y+8, 28, 18);
+    ctx.strokeRect(r.x + 0.5, r.y + 0.5, r.w - 1, r.h - 1);
+    ctx.fillStyle = "rgba(0,0,0,.5)";
+    ctx.fillRect(r.x + 8, r.y + 8, 28, 18);
     ctx.fillStyle = "rgba(233,238,246,.9)";
     ctx.font = "12px ui-monospace, Menlo, monospace";
-    ctx.fillText(label, r.x+18, r.y+22);
+    ctx.fillText(label, r.x + 18, r.y + 22);
   }
 
-  function drawAgent(ent, fill){
-    // glow
-    ctx.fillStyle = "rgba(0,0,0,.20)";
-    ctx.beginPath(); ctx.arc(ent.x, ent.y, 28, 0, Math.PI*2); ctx.fill();
-    // body
-    ctx.fillStyle = fill;
-    ctx.beginPath(); ctx.arc(ent.x, ent.y, 18, 0, Math.PI*2); ctx.fill();
-    // facing dot
-    const tx = (mouse.x - cam.x), ty = (mouse.y - cam.y);
-    const a = Math.atan2(ty - ent.y, tx - ent.x);
-    ctx.fillStyle = "rgba(0,0,0,.35)";
-    ctx.beginPath(); ctx.arc(ent.x + Math.cos(a)*8, ent.y + Math.sin(a)*8, 4, 0, Math.PI*2); ctx.fill();
+  function drawAgent(ent, fill, aimAngle, alive) {
+    const alpha = alive ? 1 : 0.35;
+    // Shadow glow
+    ctx.globalAlpha = 0.20 * alpha;
+    ctx.fillStyle = "rgba(0,0,0,1)";
+    ctx.beginPath(); ctx.arc(ent.x, ent.y, 28, 0, Math.PI * 2); ctx.fill();
+    // Body
+    ctx.globalAlpha = alive ? 1 : 0.4;
+    ctx.fillStyle = alive ? fill : "rgba(120,120,120,.7)";
+    ctx.beginPath(); ctx.arc(ent.x, ent.y, PLAYER_R, 0, Math.PI * 2); ctx.fill();
+    // Facing dot
+    const a = aimAngle ?? 0;
+    ctx.fillStyle = "rgba(0,0,0,.45)";
+    ctx.beginPath(); ctx.arc(ent.x + Math.cos(a) * 8, ent.y + Math.sin(a) * 8, 4, 0, Math.PI * 2); ctx.fill();
+    ctx.globalAlpha = 1;
   }
 
-  function drawName(text, x, y, color){
+  function drawName(text, x, y, color) {
     ctx.font = "12px ui-monospace, Menlo, monospace";
     const w = ctx.measureText(text).width;
-    ctx.fillStyle = "rgba(0,0,0,.45)";
-    ctx.fillRect(x - w/2 - 6, y - 12, w + 12, 16);
+    ctx.fillStyle = "rgba(0,0,0,.5)";
+    ctx.fillRect(x - w / 2 - 6, y - 12, w + 12, 16);
     ctx.fillStyle = color;
-    ctx.fillText(text, x - w/2, y);
+    ctx.fillText(text, x - w / 2, y);
   }
 })();
 </script>

--- a/game/server.js
+++ b/game/server.js
@@ -1,74 +1,299 @@
 import { WebSocketServer } from "ws";
 
 const wss = new WebSocketServer({ port: 8787 });
-console.log("WS server on ws://0.0.0.0:8787");
+console.log("[AIRA-LAN] WS server → ws://0.0.0.0:8787");
 
+// ── Map constants (mirrored from client) ──────────────────────────────────────
+const WORLD = { w: 2400, h: 1500 };
+const SITES = {
+  A: { x: 1900, y: 260,  w: 260, h: 220 },
+  B: { x: 300,  y: 250,  w: 260, h: 220 },
+};
+const SPAWNS = {
+  T:  [{ x: 220, y: 1300 }, { x: 320, y: 1260 }, { x: 260, y: 1180 }],
+  CT: [{ x: 2140, y: 240  }, { x: 2040, y: 320  }, { x: 2200, y: 340  }],
+};
+const PLAYER_R    = 18;
+const PLANT_TIME  = 1.6;
+const DEFUSE_TIME = 3.2;
+const BOMB_TIMER  = 35.0;
+const FREEZE_TIME = 4.0;
+const LIVE_TIME   = 70.0;
+const END_TIME    = 4.0;
+
+// ── Game state (server-authoritative) ────────────────────────────────────────
+let roundNum   = 1;
+let roundState = freshRound();
+let bombState  = freshBomb();
+const score    = { T: 0, CT: 0 };
+const killFeed = []; // [{killer, victim}] newest first, max 10
+
+function freshRound() {
+  return { phase: "freeze", phaseLeft: FREEZE_TIME, liveLeft: LIVE_TIME, winner: null, reason: "" };
+}
+function freshBomb() {
+  return { status: "carried", plantedSite: null, x: null, y: null, timer: 0, plantProgress: 0, defuseProgress: 0 };
+}
+
+// ── Clients ───────────────────────────────────────────────────────────────────
 let nextId = 1;
-const clients = new Map(); // ws -> {id,name,team,x,y,hp}
+// ws → { id, name, team, x, y, aim, hp, alive }
+const clients = new Map();
 
-function broadcast(obj){
-  const msg = JSON.stringify(obj);
-  for (const ws of clients.keys()){
-    if (ws.readyState === 1) ws.send(msg);
+// ── Utilities ─────────────────────────────────────────────────────────────────
+function send(ws, obj) {
+  if (ws.readyState === 1) ws.send(JSON.stringify(obj));
+}
+function broadcast(obj, exclude = null) {
+  const s = JSON.stringify(obj);
+  for (const ws of clients.keys()) {
+    if (ws !== exclude && ws.readyState === 1) ws.send(s);
+  }
+}
+function inRect(px, py, r) {
+  return px >= r.x && px <= r.x + r.w && py >= r.y && py <= r.y + r.h;
+}
+function randSpawn(team) {
+  const list = SPAWNS[team] ?? SPAWNS.T;
+  return list[Math.floor(Math.random() * list.length)];
+}
+function snapshot() {
+  return Array.from(clients.values()).map(p => ({
+    id: p.id, name: p.name, team: p.team,
+    x: p.x,  y: p.y,       aim: p.aim,
+    hp: p.hp, alive: p.alive,
+  }));
+}
+function broadcastFull() {
+  broadcast({
+    t:       "full",
+    players: snapshot(),
+    round:   { ...roundState, roundNum },
+    bomb:    { ...bombState },
+    score:   { ...score },
+    kills:   killFeed.slice(0, 5),
+  });
+}
+function addKill(killer, victim) {
+  killFeed.unshift({ killer, victim, ts: Date.now() });
+  if (killFeed.length > 10) killFeed.pop();
+}
+
+// ── Round management ─────────────────────────────────────────────────────────
+function endRound(winner, reason) {
+  if (roundState.phase === "end") return;
+  roundState.phase    = "end";
+  roundState.winner   = winner;
+  roundState.reason   = reason;
+  roundState.phaseLeft = END_TIME;
+  score[winner]++;
+  console.log(`[round ${roundNum}] ${winner} wins — ${reason} | Score T:${score.T} CT:${score.CT}`);
+  broadcastFull();
+}
+
+function resetRound() {
+  roundNum++;
+  roundState = freshRound();
+  bombState  = freshBomb();
+  for (const [ws, p] of clients) {
+    p.hp    = 100;
+    p.alive = true;
+    const sp = randSpawn(p.team);
+    p.x = sp.x; p.y = sp.y;
+    send(ws, { t: "respawn", x: sp.x, y: sp.y });
+  }
+  console.log(`[round ${roundNum}] starting — freeze`);
+  broadcastFull();
+}
+
+function checkElimination() {
+  if (roundState.phase !== "live") return;
+  const all     = Array.from(clients.values());
+  const tAlive  = all.some(p => p.team === "T"  && p.alive);
+  const ctAlive = all.some(p => p.team === "CT" && p.alive);
+  if (!tAlive && bombState.status !== "planted") {
+    endRound("CT", "Eliminación T");
+  } else if (!ctAlive) {
+    endRound("T", "Eliminación CT");
   }
 }
 
-function snapshot(){
-  return Array.from(clients.values()).map(p => ({
-    id:p.id, name:p.name, team:p.team, x:p.x, y:p.y, hp:p.hp
-  }));
-}
+// ── Server loop (10 Hz) ───────────────────────────────────────────────────────
+let lastTick = Date.now();
+setInterval(() => {
+  if (clients.size === 0) return;
 
+  const now = Date.now();
+  const dt  = Math.min(0.2, (now - lastTick) / 1000);
+  lastTick  = now;
+
+  if (roundState.phase === "freeze") {
+    roundState.phaseLeft -= dt;
+    if (roundState.phaseLeft <= 0) {
+      roundState.phase    = "live";
+      roundState.phaseLeft = 0;
+    }
+  } else if (roundState.phase === "live") {
+    if (bombState.status === "planted") {
+      bombState.timer -= dt;
+      if (bombState.timer <= 0) {
+        bombState.status = "exploded";
+        endRound("T", "Bomba explotó");
+        return;
+      }
+    } else {
+      roundState.liveLeft -= dt;
+      if (roundState.liveLeft <= 0) {
+        endRound("CT", "Tiempo");
+        return;
+      }
+    }
+  } else if (roundState.phase === "end") {
+    roundState.phaseLeft -= dt;
+    if (roundState.phaseLeft <= 0) {
+      resetRound();
+      return;
+    }
+  }
+
+  broadcastFull();
+}, 100);
+
+// ── WebSocket connections ─────────────────────────────────────────────────────
 wss.on("connection", (ws) => {
   const id = nextId++;
-  clients.set(ws, { id, name:`P${id}`, team:"T", x:1200, y:750, hp:100 });
+  const sp = randSpawn("T");
+  clients.set(ws, { id, name: `P${id}`, team: "T", x: sp.x, y: sp.y, aim: 0, hp: 100, alive: true });
+  send(ws, { t: "you", id });
+  send(ws, { t: "respawn", x: sp.x, y: sp.y });
+  broadcastFull();
+  console.log(`[connect] P${id} joined (${clients.size} online)`);
 
-  ws.send(JSON.stringify({ t:"you", id }));
-
-  ws.on("message", (data) => {
+  ws.on("message", raw => {
     let msg;
-    try { msg = JSON.parse(String(data)); } catch { return; }
-
+    try { msg = JSON.parse(String(raw)); } catch { return; }
     const me = clients.get(ws);
     if (!me) return;
 
-    if (msg.t === "join"){
-      me.name = msg.name || me.name;
-      me.team = msg.team === "CT" ? "CT" : "T";
-      broadcast({ t:"state", players: snapshot() });
-      return;
-    }
+    switch (msg.t) {
 
-    if (msg.t === "pos"){
-      me.x = msg.x; me.y = msg.y;
-      me.hp = msg.hp ?? me.hp;
-      me.team = msg.team === "CT" ? "CT" : "T";
-      me.name = msg.name || me.name;
-      // rate simple: broadcast state always (ok para LAN pequeña)
-      broadcast({ t:"state", players: snapshot() });
-      return;
-    }
+      // ── join ──────────────────────────────────────────────────────────────
+      case "join": {
+        me.name = String(msg.name || me.name).slice(0, 32);
+        me.team = msg.team === "CT" ? "CT" : "T";
+        if (roundState.phase !== "live") {
+          const sp = randSpawn(me.team);
+          me.x = sp.x; me.y = sp.y;
+          send(ws, { t: "respawn", x: sp.x, y: sp.y });
+        }
+        broadcastFull();
+        break;
+      }
 
-    if (msg.t === "shot"){
-      broadcast({ t:"shot", id: me.id, x: msg.x, y: msg.y, vx: msg.vx, vy: msg.vy });
-      return;
-    }
+      // ── pos (position update from client) ─────────────────────────────────
+      case "pos": {
+        if (!me.alive) break;
+        if (typeof msg.x === "number") me.x = Math.max(0, Math.min(WORLD.w, msg.x));
+        if (typeof msg.y === "number") me.y = Math.max(0, Math.min(WORLD.h, msg.y));
+        if (typeof msg.aim === "number") me.aim = msg.aim;
+        me.name = String(msg.name || me.name).slice(0, 32);
+        me.team = msg.team === "CT" ? "CT" : "T";
+        // Position updates are batched — broadcast happens in tick loop
+        break;
+      }
 
-    if (msg.t === "bomb"){
-      broadcast({ t:"bomb", bombState: msg.bombState });
-      return;
-    }
+      // ── shot (visual relay only — hit detection is client-reported) ────────
+      case "shot": {
+        if (!me.alive || roundState.phase !== "live") break;
+        broadcast({ t: "shot", id: me.id, x: msg.x, y: msg.y, vx: msg.vx, vy: msg.vy }, ws);
+        break;
+      }
 
-    if (msg.t === "round"){
-      broadcast({ t:"round", roundState: msg.roundState });
-      return;
+      // ── hit (client detected bullet hitting a remote player) ───────────────
+      case "hit": {
+        if (!me.alive || roundState.phase !== "live") break;
+        const targetId = Number(msg.targetId);
+        const damage   = Math.max(1, Math.min(100, Math.round(Number(msg.damage) || 20)));
+
+        let target = null, targetWs = null;
+        for (const [tw, tp] of clients) {
+          if (tp.id === targetId) { target = tp; targetWs = tw; break; }
+        }
+        if (!target || !target.alive || target.team === me.team) break;
+
+        // Plausibility check: positions must be within a reasonable range
+        const dx = target.x - me.x, dy = target.y - me.y;
+        const dist = Math.sqrt(dx*dx + dy*dy);
+        if (dist > 1200) break; // too far — likely stale position
+
+        target.hp = Math.max(0, target.hp - damage);
+        console.log(`[hit] ${me.name} → ${target.name} (${damage}dmg, hp=${target.hp})`);
+
+        if (target.hp === 0) {
+          target.alive = false;
+          addKill(me.name, target.name);
+          send(targetWs, { t: "killed", by: me.name });
+          broadcastFull();
+          checkElimination();
+        } else {
+          send(targetWs, { t: "damage", amount: damage, from: me.name });
+          broadcastFull();
+        }
+        break;
+      }
+
+      // ── plant (T presses E in bomb site) ──────────────────────────────────
+      case "plant": {
+        if (!me.alive || roundState.phase !== "live" || me.team !== "T") break;
+        if (bombState.status !== "carried") break;
+        const site = inRect(me.x, me.y, SITES.A) ? "A"
+                   : inRect(me.x, me.y, SITES.B) ? "B" : null;
+        if (!site) { bombState.plantProgress = 0; break; }
+
+        bombState.plantProgress = Math.min(1, Number(msg.progress) || 0);
+        if (bombState.plantProgress >= 1) {
+          bombState.status        = "planted";
+          bombState.plantedSite   = site;
+          bombState.x             = me.x;
+          bombState.y             = me.y;
+          bombState.timer         = BOMB_TIMER;
+          bombState.plantProgress = 0;
+          console.log(`[bomb] planted at site ${site} by ${me.name}`);
+        }
+        break;
+      }
+
+      // ── defuse (CT presses E near bomb) ───────────────────────────────────
+      case "defuse": {
+        if (!me.alive || roundState.phase !== "live" || me.team !== "CT") break;
+        if (bombState.status !== "planted") break;
+        const dx = me.x - (bombState.x || 0);
+        const dy = me.y - (bombState.y || 0);
+        if (dx*dx + dy*dy > 80*80) { bombState.defuseProgress = 0; break; }
+
+        bombState.defuseProgress = Math.min(1, Number(msg.progress) || 0);
+        if (bombState.defuseProgress >= 1) {
+          bombState.status         = "defused";
+          bombState.defuseProgress = 0;
+          endRound("CT", "Defuse");
+        }
+        break;
+      }
+
+      // ── actionStop (released E) ────────────────────────────────────────────
+      case "actionStop": {
+        bombState.plantProgress  = 0;
+        bombState.defuseProgress = 0;
+        break;
+      }
     }
   });
 
   ws.on("close", () => {
+    const p = clients.get(ws);
     clients.delete(ws);
-    broadcast({ t:"state", players: snapshot() });
+    console.log(`[disconnect] ${p?.name ?? "?"} left (${clients.size} online)`);
+    broadcastFull();
+    checkElimination();
   });
-
-  broadcast({ t:"state", players: snapshot() });
 });

--- a/index.html
+++ b/index.html
@@ -25,8 +25,6 @@
         <span class="brand-sep">/</span>
         <span class="brand-sub">LAN</span>
       </a>
-      <a href="#juego">Juego</a>
-
       <button class="nav-toggle" id="navToggle" aria-label="Abrir menú" aria-expanded="false">
         <span></span><span></span><span></span>
       </button>
@@ -34,10 +32,10 @@
       <div class="nav-links" id="navLinks">
         <a href="#home">Home</a>
         <a href="#proxima">Próxima LAN</a>
-        <a href="#jugadores">Jugadores</a>
-        <a href="#juegos">Juegos</a>
-        <a href="#descargas">Descargas</a>
+        <a href="#jugadores">Roster</a>
+        <a href="#juegos">Juegos &amp; Descargas</a>
         <a href="#historial">Historial</a>
+        <a href="#juego">Mini-CS 2D</a>
         <a class="cta" href="#cuentas">Crear cuenta</a>
       </div>
     </nav>
@@ -65,7 +63,7 @@
         <div class="countdown-bar">
           <div class="countdown-label">
             <span class="dot pulse"></span>
-            PRÓXIMA LAN — SÁB 28 FEB · 18:00HS
+            PRÓXIMA LAN — SÁB 30 MAY · 18:00HS
           </div>
           <div class="countdown-timer">
             <div class="cd-unit"><span class="cd-num" id="cd-d">00</span><span class="cd-lbl">días</span></div>
@@ -81,7 +79,7 @@
         <div class="hero-actions">
           <a class="btn primary" href="#cuentas">Crear cuenta WoW</a>
           <a class="btn ghost" href="#conexion">Cómo conectarse</a>
-          <a class="btn ghost" href="#descargas">Descargar cliente</a>
+          <a class="btn ghost" href="#juegos">Descargar cliente</a>
         </div>
 
         <div class="quick-stats">
@@ -146,8 +144,8 @@
     <div class="container">
       <div class="section-head">
         <div class="section-tag">PRÓXIMO EVENTO</div>
-        <h2>LAN Party <span class="accent">#01</span></h2>
-        <p>Sábado 28 de febrero · 18:00 a 04:00hs · Ubicación: <span class="secret" title="¿De verdad creés que te vamos a decir?">[ CLASIFICADO ]</span></p>
+        <h2>LAN Party <span class="accent">#02</span></h2>
+        <p>Sábado 30 de Mayo · 18:00 a 04:00hs · Ubicación: <span class="secret" title="¿De verdad creés que te vamos a decir?">[ CLASIFICADO ]</span></p>
       </div>
 
       <div class="event-grid">
@@ -349,13 +347,13 @@
   </div>
 </section>
 
-  <!-- Juegos -->
+  <!-- Juegos & Descargas -->
   <section id="juegos" class="section">
     <div class="container">
       <div class="section-head">
-        <div class="section-tag">ARSENAL</div>
-        <h2>Juegos disponibles</h2>
-        <p>El lineup de esta LAN. La idea es sumar más con el tiempo.</p>
+        <div class="section-tag">ARSENAL &amp; DOWNLOADS</div>
+        <h2>Juegos <span class="accent">&amp;</span> Descargas</h2>
+        <p>El lineup de esta LAN y todo lo que necesitás para conectarte.</p>
       </div>
 
       <div class="cards">
@@ -399,19 +397,9 @@
           </div>
         </article>
       </div>
-    </div>
-  </section>
 
-  <!-- Descargas -->
-  <section id="descargas" class="section">
-    <div class="container">
-      <div class="section-head">
-        <div class="section-tag">DOWNLOADS</div>
-        <h2>Descargas</h2>
-        <p>Descargá el cliente de WoW (Pandaria 5.0.x) y seguí los pasos para conectarte.</p>
-      </div>
-
-      <div class="split">
+      <!-- Descargas integradas -->
+      <div id="descargas" class="split" style="margin-top:32px;">
         <div class="box">
           <h3>⚔️ Cliente WoW Pandaria (5.0.x)</h3>
           <p>Descargá el cliente completo desde Google Drive.</p>
@@ -573,7 +561,7 @@
         </div>
       </div>
 
-      <!-- LAN #02 (PRIMAVERA / MAYO) -->
+      <!-- LAN #02 (OTOÑO / MAYO) -->
       <div class="timeline-item">
         <div class="tl-marker">
           <div class="tl-dot pulse"></div>
@@ -583,9 +571,14 @@
             <span class="tl-num">#02</span>
             <div>
               <div class="tl-title">Edición Otoño</div>
-              <div class="tl-date">Mayo 2026 · Fecha a confirmar</div>
+              <div class="tl-date">Sáb 30 de Mayo 2026 · 18:00 — 04:00hs</div>
             </div>
             <span class="tag" data-status="up">PRÓXIMA</span>
+          </div>
+          <div class="tl-games">
+            <span class="tl-game">🎯 CS2</span>
+            <span class="tl-game">💥 CoD4 MW</span>
+            <span class="tl-game">⚔️ WoW Pandaria</span>
           </div>
           <div class="tl-players muted-text">Se viene el Otoño, pero el tilt no se va.</div>
         </div>
@@ -768,9 +761,10 @@
       <div class="footer-links">
         <a href="#home">Home</a>
         <a href="#proxima">Próxima LAN</a>
-        <a href="#jugadores">Jugadores</a>
+        <a href="#jugadores">Roster</a>
+        <a href="#juegos">Juegos &amp; Descargas</a>
         <a href="#historial">Historial</a>
-        <a href="#descargas">Descargas</a>
+        <a href="#juego">Mini-CS 2D</a>
       </div>
 
       <div class="footer-right small">


### PR DESCRIPTION
Game (Mini-CS 2D):
- Server-authoritative round & bomb state (10Hz tick loop)
- Server-side hit validation with plausibility distance check
- Kill feed: server tracks kills, broadcasts to all clients
- Client sends aim angle; remote players now rendered with correct facing direction
- Local bullet hit detection against remote players → sends `hit` msg to server
- Player dead/spectate state: translucent body, MUERTO overlay, can't move/shoot
- Server handles respawn: sends `respawn` msg with team spawn coords on new round
- In-canvas round-end overlay with winner + score
- Plant/defuse progress bar drawn on canvas
- Scoreboard (T: X · CT: X) in HUD
- Expanding pulsing bomb ring animation when planted
- Online/offline mode split: server drives state online, local sim offline
- Remote bullets shown in red to distinguish from own bullets
- Crosshair gap expands dynamically with recoil

Site (index.html / app.js):
- Nav: renamed Jugadores → Roster, merged Juegos + Descargas → Juegos & Descargas, added Mini-CS 2D link
- Countdown updated to Sáb 30 Mayo 2026 18:00hs ART
- Próxima LAN section updated to LAN #02 with confirmed date
- LAN #02 timeline entry updated with confirmed date and game list
- Footer links updated to match new nav structure
- Descargas section merged inline into Juegos section